### PR TITLE
Update Roles field to use MultiSelect

### DIFF
--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -59,7 +59,7 @@ class UserResource extends Resource
                     ->password()
                     ->maxLength(255)
                     ->dehydrateStateUsing(fn ($state) => !empty($state) ? Hash::make($state) : ""),
-                Forms\Components\BelongsToManyMultiSelect::make('roles')->relationship('roles', 'name')->label(trans('filament-user::user.resource.roles')),
+                Forms\Components\MultiSelect::make('roles')->relationship('roles', 'name')->label(trans('filament-user::user.resource.roles')),
             ]);
     }
 


### PR DESCRIPTION
Update Roles field to use `MultiSelect` instead of deprecated `BelongsToManyMultiSelect` field