### PR TITLE
fix: unreachable code in password dehydration

### DIFF
--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -68,10 +68,9 @@ class UserResource extends Resource
                 ->password()
                 ->maxLength(255)
                 ->dehydrateStateUsing(static function ($state) use ($form) {
-                    return !empty($state) ? Hash::make($state) : null;
-
-                    $user = User::find($form->getColumns());
-                    return $user ? $user->password : null;
+                    return !empty($state)
+                        ? Hash::make($state)
+                        : User::find($form->getColumns())?->password;
                 }),
         ];
 

--- a/stubs/UserResource.stub
+++ b/stubs/UserResource.stub
@@ -68,10 +68,9 @@ class UserResource extends Resource
                 ->password()
                 ->maxLength(255)
                 ->dehydrateStateUsing(static function ($state) use ($form) {
-                    return !empty($state) ? Hash::make($state) : null;
-
-                    $user = User::find($form->getColumns());
-                    return $user ? $user->password : null;
+                    return !empty($state)
+                            ? Hash::make($state)
+                            : User::find($form->getColumns())?->password;
                 }),
         ];
 


### PR DESCRIPTION
Resolves an issue introduced in 50be1f26086d96970d93786613a5cd29e7d08b1d in the `dehydrateStateUsing()` method for the password field where an early null return resulted in unreachable code. For context, the method previously looked like this:

https://github.com/3x1io/filament-user/blob/ceeb42a68ff06961650e635b3c647ef2a36cdee3/src/Resources/UserResource.php#L60-L68